### PR TITLE
fix(datatable): payments data prop

### DIFF
--- a/docs/content/components/data-table.md
+++ b/docs/content/components/data-table.md
@@ -255,7 +255,7 @@ export async function load() {
   let { data } = $props();
 </script>
 
-<DataTable {data} {columns} />
+<DataTable data={data.payments} {columns} />
 ```
 
 </Steps>


### PR DESCRIPTION
Rendered page data prop should be `data={data.payments}` instead of `{data}` because the page data is `{payments: ...[]}`.

```diff
# routes/payments/+page.svelte
<script lang="ts">
 import DataTable from "./data-table.svelte";
 import { columns } from "./columns.js";
 
 let { data } = $props();
</script>
 
-<DataTable {data} {columns} />
+<DataTable data={data.payments} {columns} />
```

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
